### PR TITLE
Adds sorting for locations and aos lists

### DIFF
--- a/features/calendar/ao.py
+++ b/features/calendar/ao.py
@@ -15,6 +15,7 @@ from utilities.helper_functions import (
     get_location_display_name,
     safe_convert,
     safe_get,
+    sort_by_name,
     trigger_map_revalidation,
     upload_files_to_storage,
 )
@@ -160,6 +161,8 @@ def build_ao_list_form(body: dict, client: WebClient, logger: Logger, context: d
         Org,
         [Org.parent_id == region_record.org_id, Org.org_type == Org_Type.ao, Org.is_active.is_(True)],
     )
+
+    ao_records.sort(key=sort_by_name(lambda x: x.name))
 
     blocks = [
         orm.SectionBlock(

--- a/features/calendar/location.py
+++ b/features/calendar/location.py
@@ -10,7 +10,7 @@ from slack_sdk.web import WebClient
 from features.calendar import ao
 from utilities.builders import add_loading_form
 from utilities.database.orm import SlackSettings
-from utilities.helper_functions import get_location_display_name, safe_convert, safe_get, trigger_map_revalidation
+from utilities.helper_functions import get_location_display_name, safe_convert, safe_get, sort_by_name, trigger_map_revalidation
 from utilities.slack import actions, orm
 
 
@@ -160,6 +160,7 @@ def build_location_list_form(
         [Location.org_id == Org.id, Org.parent_id == region_record.org_id, Location.is_active],
     )
     location_records.extend(record[0] for record in location_records2)
+    location_records.sort(key=sort_by_name(get_location_display_name))
 
     blocks = [
         orm.SectionBlock(

--- a/utilities/helper_functions.py
+++ b/utilities/helper_functions.py
@@ -858,3 +858,23 @@ def get_user_names_legacy(
         return names, urls
     else:
         return names
+
+# Helper function to sort by name, ignoring any prefixes we might want to ignore
+# Example: The Name, should just be sorted as Name
+def sort_by_name(extractor):
+    prefixes = ("the ",)
+    prefixes = tuple(p.casefold() for p in prefixes)
+
+    def key(obj):
+        value = (extractor(obj) or "").strip()
+        folded = value.casefold()
+
+        for p in prefixes:
+            if folded.startswith(p):
+                folded = folded[len(p):]
+                break
+
+        return folded
+
+    return key
+


### PR DESCRIPTION
Results for these lists were I think just sorted by ID, so added a sort to them.  We also tend to have a lot of aos/locations that start with "The" so added a common sorting method that will let us ignore certain prefixes like that when sorting.  

**Before**
<img width="522" height="319" alt="image" src="https://github.com/user-attachments/assets/7caf5d37-ae4c-4bd5-a4c0-0a27364e91c9" />
<img width="518" height="276" alt="image" src="https://github.com/user-attachments/assets/04de8203-137c-44a7-a07a-45d85fd03150" />

**After**
<img width="524" height="324" alt="image" src="https://github.com/user-attachments/assets/54b2afc2-216f-48a5-8db7-40b21350f196" />
<img width="518" height="275" alt="image" src="https://github.com/user-attachments/assets/b5948f23-1755-4d85-ac67-e926dde017f7" />


