### PR TITLE
Set the home region to the first joined Slack and auto-update display name

### DIFF
--- a/app_manifest.template.json
+++ b/app_manifest.template.json
@@ -147,7 +147,8 @@
             "request_url": "https://HOST-PLACEHOLDER/slack/events",
             "bot_events": [
                 "app_mention",
-                "team_join"
+                "team_join",
+                "user_change"
             ]
         },
         "interactivity": {

--- a/utilities/helper_functions.py
+++ b/utilities/helper_functions.py
@@ -294,6 +294,10 @@ def create_user(slack_user_info: dict, home_region_id: int | None = None) -> Sla
                 home_region_id=home_region_id,
             )
         )
+    elif not user_record.home_region_id and home_region_id:
+        # Set home region on first workspace join if not already established
+        DbManager.update_record(User, user_record.id, {User.home_region_id: home_region_id})
+        user_record.home_region_id = home_region_id
 
     slack_user_record = safe_get(
         DbManager.find_records(SlackUser, filters=[SlackUser.slack_id == slack_user_info.get("id")]), 0

--- a/utilities/routing.py
+++ b/utilities/routing.py
@@ -223,6 +223,7 @@ VIEW_CLOSED_MAPPER = {
 EVENT_MAPPER = {
     "team_join": (welcome.handle_team_join, False),
     "app_mention": (help.handle_app_mention, False),
+    "user_change": (welcome.handle_user_change, False),
 }
 
 OPTIONS_MAPPER = {


### PR DESCRIPTION
* It's pretty likely that the first Slack a user joins that contains the F3 app will be their home region, so we may as well default it that way and eagerly create the user.
* At the same time, most new users may not set their display name correctly upon joining, so we should listen for the `user_change` event and update their `f3_name` whenever their display name changes in their home region.