### PR TITLE
Update event instances' org_id when series AO changes

### DIFF
--- a/features/calendar/series.py
+++ b/features/calendar/series.py
@@ -498,6 +498,9 @@ def update_events(
         ],
         fields={
             EventInstance.series_id: series.id,
+            # When a series is moved to a different AO, existing event instances must get the new org_id.
+            # Otherwise they stay under the old AO (e.g. Q lineups, calendar show them in the wrong place).
+            EventInstance.org_id: series.org_id,
             EventInstance.location_id: series.location_id,
             EventInstance.start_time: series.start_time,
             EventInstance.end_time: series.end_time,


### PR DESCRIPTION
- Add `org_id` to the fields updated on existing event instances during `update_events`, syncing it with the series' `org_id`
- Fixes bug where moving a series to a different AO left existing event instances under the old AO, causing incorrect Q lineups and calendar placement
