### PR TITLE
Adds option to make calendar location based

### DIFF
--- a/features/calendar/config.py
+++ b/features/calendar/config.py
@@ -16,7 +16,7 @@ CALENDAR_CONFIG_Q_LINEUP_METHOD = "calendar_config_q_lineup_method"
 CALENDAR_CONFIG_Q_LINEUP_CHANNEL = "calendar_config_q_lineup_channel"
 CALENDAR_CONFIG_Q_LINEUP_DAY = "calendar_config_q_lineup_day"
 CALENDAR_CONFIG_Q_LINEUP_TIME = "calendar_config_q_lineup_time"
-CALENDAR_CONFIG_GROUP_BY_AO = "calendar_config_group_by_ao"
+CALENDAR_CONFIG_GROUP_BY_OPTION = "calendar_config_group_by_option"
 
 
 def build_calendar_config_form(
@@ -43,7 +43,7 @@ def build_calendar_general_config_form(
     )
     form.set_initial_values(
         {
-            CALENDAR_CONFIG_GROUP_BY_AO: "yes" if region_record.calendar_group_by_ao is not False else "no",
+            CALENDAR_CONFIG_GROUP_BY_OPTION: region_record.calendar_group_by_option or "ao",
             actions.CALENDAR_CONFIG_Q_LINEUP: "yes" if region_record.send_q_lineups else "no",
             CALENDAR_CONFIG_Q_LINEUP_METHOD: region_record.send_q_lineups_method or "yes_per_ao",
             CALENDAR_CONFIG_Q_LINEUP_CHANNEL: region_record.send_q_lineups_channel,
@@ -67,7 +67,7 @@ def handle_calendar_config_general(
 ):
     form = copy.deepcopy(CALENDAR_CONFIG_GENERAL_FORM)
     values = form.get_selected_values(body)
-    region_record.calendar_group_by_ao = safe_get(values, CALENDAR_CONFIG_GROUP_BY_AO) == "yes"
+    region_record.calendar_group_by_option = safe_get(values, CALENDAR_CONFIG_GROUP_BY_OPTION)
     region_record.send_q_lineups = safe_get(values, actions.CALENDAR_CONFIG_Q_LINEUP) == "yes"
     region_record.send_q_lineups_method = safe_get(values, CALENDAR_CONFIG_Q_LINEUP_METHOD)
     region_record.send_q_lineups_channel = safe_get(values, CALENDAR_CONFIG_Q_LINEUP_CHANNEL)
@@ -158,17 +158,17 @@ CALENDAR_CONFIG_GENERAL_FORM = orm.BlockView(
             optional=True,
         ),
         orm.InputBlock(
-            label="Group Calendar By AO",
-            action=CALENDAR_CONFIG_GROUP_BY_AO,
+            label="Group Calendar By Option",
+            action=CALENDAR_CONFIG_GROUP_BY_OPTION,
             element=orm.RadioButtonsElement(
                 options=orm.as_selector_options(
-                    names=["Yes", "No"],
-                    values=["yes", "no"],
+                    names=["AO", "Location"],
+                    values=["ao", "location"],
                 ),
-                initial_value="yes",
+                initial_value="ao",
             ),
             optional=False,
-            hint="Yes = AO-based calendar. No = location-based calendar.",
+            hint="This setting controls how rows are grouped on calendar images.",
         ),
     ]
 )

--- a/features/calendar/config.py
+++ b/features/calendar/config.py
@@ -16,6 +16,7 @@ CALENDAR_CONFIG_Q_LINEUP_METHOD = "calendar_config_q_lineup_method"
 CALENDAR_CONFIG_Q_LINEUP_CHANNEL = "calendar_config_q_lineup_channel"
 CALENDAR_CONFIG_Q_LINEUP_DAY = "calendar_config_q_lineup_day"
 CALENDAR_CONFIG_Q_LINEUP_TIME = "calendar_config_q_lineup_time"
+CALENDAR_CONFIG_GROUP_BY_AO = "calendar_config_group_by_ao"
 
 
 def build_calendar_config_form(
@@ -42,6 +43,7 @@ def build_calendar_general_config_form(
     )
     form.set_initial_values(
         {
+            CALENDAR_CONFIG_GROUP_BY_AO: "yes" if region_record.calendar_group_by_ao is not False else "no",
             actions.CALENDAR_CONFIG_Q_LINEUP: "yes" if region_record.send_q_lineups else "no",
             CALENDAR_CONFIG_Q_LINEUP_METHOD: region_record.send_q_lineups_method or "yes_per_ao",
             CALENDAR_CONFIG_Q_LINEUP_CHANNEL: region_record.send_q_lineups_channel,
@@ -65,6 +67,7 @@ def handle_calendar_config_general(
 ):
     form = copy.deepcopy(CALENDAR_CONFIG_GENERAL_FORM)
     values = form.get_selected_values(body)
+    region_record.calendar_group_by_ao = safe_get(values, CALENDAR_CONFIG_GROUP_BY_AO) == "yes"
     region_record.send_q_lineups = safe_get(values, actions.CALENDAR_CONFIG_Q_LINEUP) == "yes"
     region_record.send_q_lineups_method = safe_get(values, CALENDAR_CONFIG_Q_LINEUP_METHOD)
     region_record.send_q_lineups_channel = safe_get(values, CALENDAR_CONFIG_Q_LINEUP_CHANNEL)
@@ -153,6 +156,19 @@ CALENDAR_CONFIG_GENERAL_FORM = orm.BlockView(
             action=CALENDAR_CONFIG_CALENDAR_IMAGE_CHANNEL,
             element=orm.ChannelsSelectElement(placeholder="Select a channel"),
             optional=True,
+        ),
+        orm.InputBlock(
+            label="Group Calendar By AO",
+            action=CALENDAR_CONFIG_GROUP_BY_AO,
+            element=orm.RadioButtonsElement(
+                options=orm.as_selector_options(
+                    names=["Yes", "No"],
+                    values=["yes", "no"],
+                ),
+                initial_value="yes",
+            ),
+            optional=False,
+            hint="Yes = AO-based calendar. No = location-based calendar.",
         ),
     ]
 )

--- a/features/calendar/home.py
+++ b/features/calendar/home.py
@@ -12,6 +12,7 @@ from f3_data_models.models import (
     Attendance_x_AttendanceType,
     EventInstance,
     EventType,
+    Location,
     Org,
     Org_Type,
     Series_Exception,
@@ -31,7 +32,15 @@ from utilities import constants
 from utilities.constants import GCP_IMAGE_URL, LOCAL_DEVELOPMENT, S3_IMAGE_URL
 from utilities.database.orm import SlackSettings
 from utilities.database.special_queries import CalendarHomeQuery, get_admin_users, get_aoq_users, home_schedule_query
-from utilities.helper_functions import _parse_view_private_metadata, current_date_cst, get_user, safe_convert, safe_get
+from utilities.helper_functions import (
+    _parse_view_private_metadata,
+    current_date_cst,
+    get_location_display_name,
+    get_user,
+    safe_convert,
+    safe_get,
+    sort_by_name,
+)
 from utilities.slack import actions, orm
 
 
@@ -76,9 +85,18 @@ def build_home_form(
         metadata["user_is_admin"] = user_is_admin
 
     start_time = time.time()
+    group_by_ao = region_record.calendar_group_by_ao is not False
     ao_records = DbManager.find_records(
         Org, filters=[Org.parent_id == region_record.org_id, Org.org_type == Org_Type.ao, Org.is_active.is_(True)]
     )
+    location_records = DbManager.find_records(Location, [Location.org_id == region_record.org_id, Location.is_active])
+    location_records2 = DbManager.find_join_records2(
+        Location,
+        Org,
+        [Location.org_id == Org.id, Org.parent_id == region_record.org_id, Location.is_active],
+    )
+    location_records.extend(record[0] for record in location_records2)
+    location_records.sort(key=sort_by_name(get_location_display_name))
     event_type_records: List[EventType] = DbManager.find_records(
         EventType,
         filters=[or_(EventType.specific_org_id == region_record.org_id, EventType.specific_org_id.is_(None))],
@@ -98,13 +116,17 @@ def build_home_form(
         orm.DividerBlock(),
         orm.SectionBlock(label="*Upcoming Schedule*"),
         orm.InputBlock(
-            label="Filter AOs",
+            label="Filter AOs" if group_by_ao else "Filter Locations",
             action=actions.CALENDAR_HOME_AO_FILTER,
             element=orm.MultiStaticSelectElement(
-                placeholder="Filter AOs",
+                placeholder="Filter AOs" if group_by_ao else "Filter Locations",
                 options=orm.as_selector_options(
-                    names=[ao.name for ao in ao_records],
-                    values=[str(ao.id) for ao in ao_records],
+                    names=[ao.name for ao in ao_records]
+                    if group_by_ao
+                    else [get_location_display_name(location) for location in location_records],
+                    values=[str(ao.id) for ao in ao_records]
+                    if group_by_ao
+                    else [str(location.id) for location in location_records],
                 ),
             ),
             dispatch_action=True,
@@ -160,11 +182,11 @@ def build_home_form(
     else:
         filter_org_ids = [region_record.org_id]
 
-    filter = [
-        or_(EventInstance.org_id.in_(filter_org_ids), Org.parent_id.in_(filter_org_ids)),
-        EventInstance.start_date >= start_date,
-        EventInstance.is_active,
-    ]
+    filter = [EventInstance.start_date >= start_date, EventInstance.is_active]
+    if group_by_ao:
+        filter.append(or_(EventInstance.org_id.in_(filter_org_ids), Org.parent_id.in_(filter_org_ids)))
+    elif safe_get(existing_filter_data, actions.CALENDAR_HOME_AO_FILTER):
+        filter.append(EventInstance.location_id.in_(filter_org_ids))
 
     if safe_get(existing_filter_data, actions.CALENDAR_HOME_EVENT_TYPE_FILTER):
         event_type_ids = [int(x) for x in safe_get(existing_filter_data, actions.CALENDAR_HOME_EVENT_TYPE_FILTER)]

--- a/features/calendar/home.py
+++ b/features/calendar/home.py
@@ -85,7 +85,7 @@ def build_home_form(
         metadata["user_is_admin"] = user_is_admin
 
     start_time = time.time()
-    group_by_ao = region_record.calendar_group_by_ao is not False
+    group_by_option = region_record.calendar_group_by_option or "ao"
     ao_records = DbManager.find_records(
         Org, filters=[Org.parent_id == region_record.org_id, Org.org_type == Org_Type.ao, Org.is_active.is_(True)]
     )
@@ -116,16 +116,16 @@ def build_home_form(
         orm.DividerBlock(),
         orm.SectionBlock(label="*Upcoming Schedule*"),
         orm.InputBlock(
-            label="Filter AOs" if group_by_ao else "Filter Locations",
+            label="Filter AOs" if group_by_option == "ao" else "Filter Locations",
             action=actions.CALENDAR_HOME_AO_FILTER,
             element=orm.MultiStaticSelectElement(
-                placeholder="Filter AOs" if group_by_ao else "Filter Locations",
+                placeholder="Filter AOs" if group_by_option == "ao" else "Filter Locations",
                 options=orm.as_selector_options(
                     names=[ao.name for ao in ao_records]
-                    if group_by_ao
+                    if group_by_option == "ao"
                     else [get_location_display_name(location) for location in location_records],
                     values=[str(ao.id) for ao in ao_records]
-                    if group_by_ao
+                    if group_by_option == "ao"
                     else [str(location.id) for location in location_records],
                 ),
             ),
@@ -183,7 +183,7 @@ def build_home_form(
         filter_org_ids = [region_record.org_id]
 
     filter = [EventInstance.start_date >= start_date, EventInstance.is_active]
-    if group_by_ao:
+    if group_by_option == "ao":
         filter.append(or_(EventInstance.org_id.in_(filter_org_ids), Org.parent_id.in_(filter_org_ids)))
     elif safe_get(existing_filter_data, actions.CALENDAR_HOME_AO_FILTER):
         filter.append(EventInstance.location_id.in_(filter_org_ids))

--- a/scripts/calendar_images.py
+++ b/scripts/calendar_images.py
@@ -18,6 +18,7 @@ from f3_data_models.models import (
     EventTag_x_EventInstance,
     EventType,
     EventType_x_EventInstance,
+    Location,
     Org,
     Org_Type,
     Org_x_SlackSpace,
@@ -144,6 +145,9 @@ def generate_calendar_images(force: bool = False):
                 Org.description.label("ao_description"),
                 Org.parent_id.label("ao_parent_id"),
                 User.f3_name.label("q_name"),
+                Location.name.label("location_name"),
+                Location.description.label("location_description"),
+                Location.address_street.label("location_address_street"),
                 attendance_subquery.c.q_last_updated,
                 RegionOrg.name.label("region_name"),
                 RegionOrg.id.label("region_id"),
@@ -155,6 +159,7 @@ def generate_calendar_images(force: bool = False):
             .join(EventType, EventType_x_EventInstance.event_type_id == EventType.id)
             .join(Org, EventInstance.org_id == Org.id)
             .join(RegionOrg, RegionOrg.id == Org.parent_id)
+            .outerjoin(Location, EventInstance.location_id == Location.id)
             .outerjoin(
                 firstq_subquery,
                 and_(EventInstance.id == firstq_subquery.c.event_instance_id, firstq_subquery.c.rn == 1),
@@ -194,6 +199,7 @@ def generate_calendar_images(force: bool = False):
                     slack_app_settings: dict = region_org_record[2].settings
                     print(f"Running for {region_name}")
 
+                    group_by_ao = slack_app_settings.get("calendar_group_by_ao") is not False
                     color_dict = {
                         t.name: t.color
                         for t in event_tags
@@ -264,31 +270,54 @@ def generate_calendar_images(force: bool = False):
                             # Override label for closed events
                             df.loc[df["series_exception"] == Series_Exception.closed, "label"] = "CLOSED"
 
-                            df.loc[:, "AO\nLocation"] = df["ao_name"]  # + "\n" + df["ao_description"]
-                            df.loc[df["ao_description"].notnull(), "AO\nLocation"] = (
-                                df["ao_name"] + "\n" + df["ao_description"]
-                            )
-                            df.loc[:, "AO\nLocation2"] = df["AO\nLocation"].str.replace("The ", "")
+                            if group_by_ao:
+                                df.loc[:, "AO\nLocation"] = df["ao_name"]  # + "\n" + df["ao_description"]
+                                df.loc[df["ao_description"].notnull(), "AO\nLocation"] = (
+                                    df["ao_name"] + "\n" + df["ao_description"]
+                                )
+                                row_key_col = "AO\nLocation"
+                                value_col = "label"
+                                sort_key_col = "ao_name"
+                            else:
+                                # Create a readable location label similar to `get_location_display_name`.
+                                location_name = df["location_name"].fillna("")
+                                location_description = df["location_description"].fillna("")
+                                location_address_street = df["location_address_street"].fillna("")
+
+                                df.loc[:, "Location"] = location_name
+                                desc_mask = (df["Location"] == "") & (location_description != "")
+                                df.loc[desc_mask, "Location"] = location_description[desc_mask].str[:30]
+                                street_mask = (df["Location"] == "") & (location_address_street != "")
+                                df.loc[street_mask, "Location"] = location_address_street[street_mask].str[:30]
+                                df.loc[df["Location"] == "", "Location"] = "Unnamed Location"
+
+                                # Include AO name in the cell now that the row header is the location.
+                                df.loc[:, "cell_label"] = df["ao_name"] + "\n" + df["label"]
+                                row_key_col = "Location"
+                                value_col = "cell_label"
+                                sort_key_col = "Location"
+
                             df.loc[:, "event_day_of_week"] = df["event_date"].dt.day_name()
                             df.to_csv(f"debug_{region_name}_{week}.csv", index=False)
-                            # Combine cells for days / AOs with more than one event
-                            df.sort_values(["ao_name", "event_date", "event_time"], ignore_index=True, inplace=True)
+
+                            # Combine cells for days within the chosen grouping (AO vs location).
+                            df.sort_values([sort_key_col, "event_date", "event_time"], ignore_index=True, inplace=True)
                             prior_date = ""
                             prior_label = ""
-                            prior_ao = ""
+                            prior_group_key = ""
                             include_list = []
                             for i in range(len(df)):
                                 row2 = df.loc[i]
-                                if (row2["event_date_fmt"] == prior_date) & (row2["ao_name"] == prior_ao):
-                                    df.loc[i, "label"] = prior_label + "\n" + df.loc[i, "label"]
-                                    prior_label = df.loc[i, "label"]
+                                if (row2["event_date_fmt"] == prior_date) & (row2[sort_key_col] == prior_group_key):
+                                    df.loc[i, value_col] = prior_label + "\n" + df.loc[i, value_col]
+                                    prior_label = df.loc[i, value_col]
                                     include_list.append(False)
                                 else:
                                     if prior_label != "":
                                         include_list.append(True)
                                     prior_date = row2["event_date_fmt"]
-                                    prior_ao = row2["ao_name"]
-                                    prior_label = row2["label"]
+                                    prior_group_key = row2[sort_key_col]
+                                    prior_label = row2[value_col]
 
                             include_list.append(True)
 
@@ -297,9 +326,9 @@ def generate_calendar_images(force: bool = False):
 
                             # Reshape to wide format by date
                             df2 = df.pivot(
-                                index="AO\nLocation",
+                                index=row_key_col,
                                 columns=["event_day_of_week", "event_date_fmt"],
-                                values="label",
+                                values=value_col,
                             ).fillna("")
 
                             # Sort and enforce word wrap on labels
@@ -308,16 +337,17 @@ def generate_calendar_images(force: bool = False):
                             df2.reset_index(inplace=True)
 
                             # Take out "The " for sorting
-                            df2["AO\nLocation2"] = df2["AO\nLocation"].str.replace("The ", "")
-                            df2.sort_values(by=["AO\nLocation2"], axis=0, inplace=True)
-                            df2.drop(["AO\nLocation2"], axis=1, inplace=True)
+                            grouping_sort_col = f"{row_key_col}2"
+                            df2[grouping_sort_col] = df2[row_key_col].str.replace("The ", "")
+                            df2.sort_values(by=[grouping_sort_col], axis=0, inplace=True)
+                            df2.drop([grouping_sort_col], axis=1, inplace=True)
                             df2.reset_index(inplace=True, drop=True)
 
                             # Add timestamp footer row
                             now_cst = datetime.now(pytz.timezone("US/Central"))
                             timestamp_str = f"Last updated at {now_cst.strftime('%m/%d %I:%M %p')} CST"
                             footer_row = dict.fromkeys(df2.columns, "")
-                            footer_row["AO\nLocation"] = timestamp_str
+                            footer_row[row_key_col] = timestamp_str
                             df2 = pd.concat([df2, pd.DataFrame([footer_row])], ignore_index=True)
 
                             # Set CSS properties for th elements in dataframe

--- a/scripts/calendar_images.py
+++ b/scripts/calendar_images.py
@@ -289,7 +289,8 @@ def generate_calendar_images(force: bool = False):
                                 df.loc[desc_mask, "Location"] = location_description[desc_mask].str[:30]
                                 street_mask = (df["Location"] == "") & (location_address_street != "")
                                 df.loc[street_mask, "Location"] = location_address_street[street_mask].str[:30]
-                                df.loc[df["Location"] == "", "Location"] = "Unnamed Location"
+                                # Fallback to ao name if no location info is available
+                                df.loc[df["Location"] == "", "Location"] = df["ao_name"]
 
                                 # Include AO name in the cell now that the row header is the location.
                                 df.loc[:, "cell_label"] = df["ao_name"] + "\n" + df["label"]

--- a/scripts/calendar_images.py
+++ b/scripts/calendar_images.py
@@ -199,7 +199,7 @@ def generate_calendar_images(force: bool = False):
                     slack_app_settings: dict = region_org_record[2].settings
                     print(f"Running for {region_name}")
 
-                    group_by_ao = slack_app_settings.get("calendar_group_by_ao") is not False
+                    group_by_option = slack_app_settings.get("calendar_group_by_option") or "ao"
                     color_dict = {
                         t.name: t.color
                         for t in event_tags
@@ -270,7 +270,7 @@ def generate_calendar_images(force: bool = False):
                             # Override label for closed events
                             df.loc[df["series_exception"] == Series_Exception.closed, "label"] = "CLOSED"
 
-                            if group_by_ao:
+                            if group_by_option == "ao":
                                 df.loc[:, "AO\nLocation"] = df["ao_name"]  # + "\n" + df["ao_description"]
                                 df.loc[df["ao_description"].notnull(), "AO\nLocation"] = (
                                     df["ao_name"] + "\n" + df["ao_description"]

--- a/utilities/database/orm/__init__.py
+++ b/utilities/database/orm/__init__.py
@@ -50,7 +50,7 @@ class SlackSettings:
     special_events_post_days: Optional[int] = None
     canvas_channel: Optional[str] = None
     paxminer_schema: Optional[str] = None
-    calendar_group_by_ao: Optional[bool] = None
+    calendar_group_by_option: Optional[str] = None
     send_q_lineups: Optional[bool] = None
     send_q_lineups_method: Optional[str] = None
     send_q_lineups_channel: Optional[str] = None

--- a/utilities/database/orm/__init__.py
+++ b/utilities/database/orm/__init__.py
@@ -50,6 +50,7 @@ class SlackSettings:
     special_events_post_days: Optional[int] = None
     canvas_channel: Optional[str] = None
     paxminer_schema: Optional[str] = None
+    calendar_group_by_ao: Optional[bool] = None
     send_q_lineups: Optional[bool] = None
     send_q_lineups_method: Optional[str] = None
     send_q_lineups_channel: Optional[str] = None


### PR DESCRIPTION
## Background
So our region follows the "Location is where things happen, AO is the individual workout (with many AO sharing a location)" model.  This leads to a couple of pain points. 

1) Calendar images are long and kind of unhelpful because there are no shared rows.  https://storage.googleapis.com/f3nation-calendar-images/25209-current-pnhxonftvs.png
2) When a PAX knows _where_ they want to Q, they can't easily filter to just that location.  

## What's in this PR

1) Adds a new setting to the calendar `calendar_config_group_by_ao`.  This is the bit to determine in places if we care more about "AO" or "location".  This should default to Yes for everyone.  

2) Adds a new piece in the "General Calendar Settings" to control this value 
<img width="527" height="645" alt="image" src="https://github.com/user-attachments/assets/b16f97a7-d937-4344-a9d7-a755fe589d26" />

3) If it is location based, on the Calendar screen show a "Filter By Location" option instead of "Filter By AO" option. 
<img width="535" height="642" alt="image" src="https://github.com/user-attachments/assets/1fecc7a0-2af6-4134-9685-8452f0948459" />

4) Take the "calendar_config_group_by_ao" into consideration when generating calendar images.  If, it's not group by ao, use location names (as best we can determine) for the first column, and include the AO in the day column as well.  
<img width="836" height="285" alt="image" src="https://github.com/user-attachments/assets/ea88ad88-d57d-4251-aa52-a01a3917b599" />

## Misc
I made the robots do most of the work here, so please let me know if something seems off, or if you think this should be handled in a different way.  (Or if it's just a bad idea in general, lol) 


