### PR TITLE
Filter inactive event tags from org event tag list

### DIFF
--- a/infrastructure/api_client/event_tag_repository.py
+++ b/infrastructure/api_client/event_tag_repository.py
@@ -36,7 +36,12 @@ class ApiEventTagRepository:
         result = self._client.get(f"/v1/event-tag/org/{org_id}")
         tags_raw: list[dict] = result.get("eventTags") or result.get("results") or []
         # Mirror legacy behaviour: only return tags that belong to this org.
-        return [_parse_event_tag(t) for t in tags_raw if t.get("specificOrgId", t.get("specific_org_id")) == org_id]
+        return [
+            _parse_event_tag(t)
+            for t in tags_raw
+            if t.get("specificOrgId", t.get("specific_org_id")) == org_id
+            and t.get("isActive", t.get("is_active", True))
+        ]
 
     def get_by_id(self, tag_id: int) -> EventTagData | None:
         try:

--- a/tests/infrastructure/api_client/test_event_tag_repository.py
+++ b/tests/infrastructure/api_client/test_event_tag_repository.py
@@ -30,6 +30,20 @@ class ApiEventTagRepositoryTest(unittest.TestCase):
         self.assertEqual(result[0].id, 1)
         self.assertEqual(result[0].specific_org_id, 10)
 
+    def test_get_by_org_excludes_inactive_tags(self):
+        self.client.get.return_value = {
+            "eventTags": [
+                {"id": 1, "name": "Active", "color": "Red", "specificOrgId": 10, "isActive": True},
+                {"id": 2, "name": "Deleted", "color": "Blue", "specificOrgId": 10, "isActive": False},
+            ]
+        }
+
+        result = self.repo.get_by_org(10)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, 1)
+        self.assertEqual(result[0].name, "Active")
+
     def test_get_by_org_supports_results_fallback_and_snake_case(self):
         self.client.get.return_value = {
             "results": [
@@ -38,7 +52,7 @@ class ApiEventTagRepositoryTest(unittest.TestCase):
                     "name": "Fallback",
                     "color": None,
                     "specific_org_id": 77,
-                    "is_active": False,
+                    "is_active": True,
                     "description": "fallback payload",
                 }
             ]
@@ -49,7 +63,7 @@ class ApiEventTagRepositoryTest(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, 99)
         self.assertEqual(result[0].specific_org_id, 77)
-        self.assertFalse(result[0].is_active)
+        self.assertTrue(result[0].is_active)
 
     def test_get_by_org_returns_empty_list_when_payload_has_no_expected_keys(self):
         self.client.get.return_value = {"unexpected": []}


### PR DESCRIPTION
Fixes #118

Deleted custom event tags were still appearing in event type dropdowns after deletion.

The API repository was correctly filtering tags by org, but inactive tags (`isActive=False`) were still being returned. This change filters inactive tags out of `get_by_org()` results so soft-deleted tags no longer appear in dropdown selections.

Also adds a test to verify inactive tags are excluded from results.
