### PR TITLE
Allow regions to self-enable achievements (per-region opt-in)

### DIFF
--- a/features/achievements.py
+++ b/features/achievements.py
@@ -57,6 +57,30 @@ from utilities.helper_functions import (
 )
 from utilities.slack.sdk_orm import SdkBlockView, as_selector_options
 
+
+# =============================================================================
+# Feature availability
+# =============================================================================
+def achievements_enabled_for_region(region_record: SlackSettings) -> bool:
+    """Return whether the achievements feature is available for a region.
+
+    Achievements are available when either:
+
+    * the region's org id is in the ``ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS``
+      allowlist (set via env var by F3 Nation ops, retained as a
+      force-enable override for staged rollouts), or
+    * the region has opted in by enabling achievements in
+      *F3 Nation Settings -> Achievement Settings* (``send_achievements``).
+
+    The Achievement Settings modal itself is always reachable so that an
+    admin can flip the opt-in; only the downstream surfaces (e.g. manual
+    achievement tagging) are gated on this check.
+    """
+    if region_record.org_id in ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS:
+        return True
+    return bool(region_record.send_achievements)
+
+
 # =============================================================================
 # Action IDs
 # =============================================================================
@@ -689,24 +713,15 @@ def build_config_form(body: dict, client: WebClient, logger: Logger, context: di
     """Build and display the achievement configuration modal."""
     trigger_id = safe_get(body, "trigger_id")
 
-    if region_record.org_id not in ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS:
-        form = SdkBlockView(
-            blocks=[
-                SectionBlock(
-                    text=MarkdownTextObject(
-                        text=":construction: This feature is currently in alpha testing, coming soon to all regions! :construction:"  # noqa E501
-                    ),
-                ),
-            ]
-        )
-        submit = "None"
-    else:
-        service = AchievementService()
-        views = AchievementViews()
+    # The Achievement Settings modal is the entry point for the per-region
+    # opt-in (the "Enable achievements" toggle writes ``send_achievements``),
+    # so it must always be reachable by an admin.
+    service = AchievementService()
+    views = AchievementViews()
 
-        achievements = service.get_all_achievements(region_record.org_id)
-        form = views.build_config_modal(region_record, achievements)
-        submit = "Submit"
+    achievements = service.get_all_achievements(region_record.org_id)
+    form = views.build_config_modal(region_record, achievements)
+    submit = "Submit"
 
     form.post_modal(
         client=client,
@@ -929,12 +944,12 @@ def build_tag_achievement_form(
     from utilities.slack import forms as legacy_forms
     from utilities.slack import orm as legacy_orm
 
-    if region_record.org_id not in ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS:
+    if not achievements_enabled_for_region(region_record):
         form = SdkBlockView(
             blocks=[
                 SectionBlock(
                     text=MarkdownTextObject(
-                        text=":construction: This feature is currently in alpha testing, coming soon to all regions! :construction:"  # noqa E501
+                        text="Achievements aren't enabled for your region yet. An admin can turn them on in *F3 Nation Settings → Achievement Settings*."  # noqa E501
                     ),
                 ),
             ]

--- a/features/config.py
+++ b/features/config.py
@@ -38,8 +38,10 @@ def build_config_form(body: dict, client: WebClient, logger: Logger, context: di
 
         if user_is_admin:
             config_form = copy.deepcopy(forms.CONFIG_FORM)
-            if region_record.org_id in constants.ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS:
-                config_form.blocks[0].elements.append(copy.deepcopy(forms.ACHIEVEMENT_BUTTON))
+            # The Achievement Settings button is the entry point for the
+            # per-region opt-in, so show it to every admin (not just orgs in
+            # the ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS allowlist).
+            config_form.blocks[0].elements.append(copy.deepcopy(forms.ACHIEVEMENT_BUTTON))
         else:
             if region_record.org_id is None:
                 config_form = copy.deepcopy(forms.CONFIG_NO_ORG_FORM)

--- a/tests/features/test_achievements.py
+++ b/tests/features/test_achievements.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from features import achievements
+from utilities.database.orm import SlackSettings
+
+
+def _make_region_record(org_id=10, send_achievements=None):
+    return SlackSettings(team_id="T123", org_id=org_id, send_achievements=send_achievements)
+
+
+class TestAchievementsEnabledForRegion(unittest.TestCase):
+    """Unit tests for the per-region achievements opt-in gate."""
+
+    def test_disabled_by_default(self):
+        # A region that is neither in the alpha allowlist nor opted in has no access.
+        with patch.object(achievements, "ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS", []):
+            record = _make_region_record(org_id=10, send_achievements=None)
+            self.assertFalse(achievements.achievements_enabled_for_region(record))
+
+    def test_enabled_via_region_opt_in(self):
+        # Enabling achievements in region settings (send_achievements) grants access.
+        with patch.object(achievements, "ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS", []):
+            record = _make_region_record(org_id=10, send_achievements=1)
+            self.assertTrue(achievements.achievements_enabled_for_region(record))
+
+    def test_enabled_via_alpha_allowlist_override(self):
+        # The env-var allowlist remains a force-enable override even without opt-in.
+        with patch.object(achievements, "ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS", [10]):
+            record = _make_region_record(org_id=10, send_achievements=None)
+            self.assertTrue(achievements.achievements_enabled_for_region(record))
+
+    def test_opt_out_disables_for_non_alpha_org(self):
+        # send_achievements explicitly off (0) keeps a non-alpha region gated.
+        with patch.object(achievements, "ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS", [99]):
+            record = _make_region_record(org_id=10, send_achievements=0)
+            self.assertFalse(achievements.achievements_enabled_for_region(record))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Hey F3 Nation — this is **Greco from F3 Tornado Alley** (org `35003`). We've been spinning up our regional presence and want to use the achievements feature, but it's currently locked behind the `ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS` env var, which only Nation ops can set. The award engine, config UI, and manual tagging are all built — they're just unreachable for most regions.

This PR turns that hard alpha gate into a **per-region opt-in**, so a region can enable achievements for itself without an ops change, while keeping the env allowlist as a force-enable override for staged rollout.

## What changed

- **New helper `achievements_enabled_for_region(region_record)`** — a region has access when either:
  - its org is in `ACHIEVEMENTS_ALPHA_TESTING_ORG_IDS` (retained as an override), **or**
  - it has enabled achievements in *F3 Nation Settings → Achievement Settings* (the existing `send_achievements` toggle).
- **Settings menu** (`features/config.py`): the Achievement Settings button is now shown to every admin (it's the entry point for the opt-in), not just alpha orgs.
- **Achievement config modal** (`features/achievements.py`): always opens, so an admin can flip the opt-in. The `:construction:` alpha notice is removed here.
- **Manual tagging** (`/tag-achievement`): gated on the new helper. If a region hasn't opted in, the modal now points the admin to the settings toggle instead of showing the generic alpha notice.

## Why this is safe

Awarding behavior is **unchanged**. The daily award engine (`scripts/award_achievements.py`) already gates channel announcements on `send_achievements` (see the per-region check around line 617), and computation/awarding was already global. This PR only changes which regions can *reach* the config + tagging surfaces.

## Testing

- Added `tests/features/test_achievements.py` covering the opt-in gate (default-off, opt-in on, alpha override, explicit opt-out).
- `ruff check` clean; new tests pass locally.

Happy to adjust naming or UX (e.g. a dedicated "enable" flag separate from `send_achievements`) if you'd prefer — wanted to keep the change minimal and reuse the existing toggle. Tornado Alley is glad to be a guinea pig if it helps. 🌪️
